### PR TITLE
Russian translation remake

### DIFF
--- a/Russian/Keyed/Multiplayer.xml
+++ b/Russian/Keyed/Multiplayer.xml
@@ -32,7 +32,7 @@
   <MpWrongVersionUpdateInfo>Обновите мод (Переподпишитесь если используете Steam).</MpWrongVersionUpdateInfo>
   <MpWrongVersionUpdateInfoHost>Хост должен обновить мод (Переподписаться если использует Steam).</MpWrongVersionUpdateInfoHost>
   <MpServerClosed>Сервер закрыт</MpServerClosed>
-  <MpServerFull>Сервер полн</MpServerFull>
+  <MpServerFull>Сервер полон</MpServerFull>
   <MpDisconnectServerStarting>Сервер запускается</MpDisconnectServerStarting>
   <MpKicked>Вы были исключены из игры</MpKicked>
   <MpDisconnected>Отключен</MpDisconnected>
@@ -55,7 +55,7 @@
   <MpPlayerConnected>{0} подключился</MpPlayerConnected>
   <MpPlayerDisconnected>{0} вышел</MpPlayerDisconnected>
   <MpChatPlayers>Игроки ({0}):</MpChatPlayers>
-  <MpChatSend>Отправить</MpChatSend>
+  <MpChatSend>⏎</MpChatSend> <!-- длинна строки макс 6 -->
     <!-- Need testing Не уверен, как выглядит это окн -->
   <MpSteamAcceptTitle>Принять игроков из Steam</MpSteamAcceptTitle>
   <MpSteamAcceptDesc>Нажмите чтобы принять</MpSteamAcceptDesc>
@@ -73,12 +73,12 @@
   <MpGameSaveFailed>Ошибка сохранения игры, Вы можете изучить лог ошибок для дополнительной информации.</MpGameSaveFailed>
 
   <!-- Settings -->
-  <MpUsernameSetting>Имя пользователя</MpUsernameSetting>
+  <MpUsernameSetting>Имя пользователя</MpUsernameSetting> <!-- длинна строки макс 16 -->
   <MpShowPlayerCursors>Показывать курсоры игроков</MpShowPlayerCursors>
   <MpAutoAcceptSteam>Авто-принятие игроков Steam</MpAutoAcceptSteam>
   <MpAutoAcceptSteamDesc>Автоматически принимает любые входящие запросы на подключение от игроков в Steam.</MpAutoAcceptSteamDesc>
   <MpTransparentChat>Прозрачное окно чата</MpTransparentChat>
-  <MpAutosaveSlots>Слоты автосохранения</MpAutosaveSlots>
+  <MpAutosaveSlots>Слоты автосо-ния</MpAutosaveSlots> <!-- длинна строки макс 16 -->
   <MpAutosaveSlotsDesc>Как много хранить файлов автосохранения.</MpAutosaveSlotsDesc>
   <MpAggressiveTicking>Агрессивные тики</MpAggressiveTicking>
   <MpAggressiveTickingDesc>Всегда пытаться автоматически догонять сервер ценой fps.</MpAggressiveTickingDesc>
@@ -86,9 +86,9 @@
   <MpShowModCompat>Показывать совместимость модов</MpShowModCompat>
   <MpShowModCompatDesc>Активирует загрузку и отображение рейтинга совместимости для модов на основе отзывов других игроков</MpShowModCompatDesc>
   <MpEnablePingsSetting>Включить метки игроков</MpEnablePingsSetting> <!-- Метки = ping -->
-  <MpPingLocButtonSetting>Кнопка создания меток</MpPingLocButtonSetting>
-  <MpJumpToPingButtonSetting>Кнопка перемещения к метке</MpJumpToPingButtonSetting>
-  <MpShowMainMenuAnimation>Показывать анимацию в главном меню</MpShowMainMenuAnimation>
+  <MpPingLocButtonSetting>Cоздать метку</MpPingLocButtonSetting> <!-- длинна строки макс ~13 -->
+  <MpJumpToPingButtonSetting>Переместится к метке</MpJumpToPingButtonSetting> <!-- длинна строки макс ~13 но может быть перенос -->
+  <MpShowMainMenuAnimation>Показывать анимацию в глав. меню</MpShowMainMenuAnimation> <!-- длинна строки макс 32 -->
   
   <!-- Ping alert -->
   <MpAlertPing>Многопользовательская метка</MpAlertPing>
@@ -128,9 +128,9 @@
   <MpInvalidEndpoint>Недопустимый адрес: {0}</MpInvalidEndpoint>
   <MpInvalidGameName>Недопустимое название игры</MpInvalidGameName>
   <MpGameName>Название игры</MpGameName>
-  <MpMaxPlayers>Максимальное количество игроков</MpMaxPlayers>
-  <MpAutosaveIntervalMinutes>Период автосохранения (минуты)</MpAutosaveIntervalMinutes>
-  <MpAutosaveIntervalDays>Период автосохранения (дни)</MpAutosaveIntervalDays>
+  <MpMaxPlayers>Кол-во игроков</MpMaxPlayers> <!-- длинна строки макс 14  -->
+  <MpAutosaveIntervalMinutes>Период автосох-ния(минуты)</MpAutosaveIntervalMinutes>  <!-- длинна строки макс 26  -->
+  <MpAutosaveIntervalDays>Период автосох-ния(дни)</MpAutosaveIntervalDays>  <!-- длинна строки макс 26  -->
   <MpAutosaveIntervalDesc1>Интервал между автосохранениями.</MpAutosaveIntervalDesc1>
   <MpAutosaveIntervalDesc2>Нажмите чтобы переключится между игровыми днями, и реальными минутами.</MpAutosaveIntervalDesc2>
   <MpAutosaveIntervalDesc3>Один игровой день на нормальной скорости равен примерно 16.6 минутам (быстрой: 5.5 минут, супер-быстрой: 2.7 минуты)</MpAutosaveIntervalDesc3>
@@ -138,22 +138,22 @@
   <MpLanDesc2>Ваш LAN адрес: {0}</MpLanDesc2> <!-- Адрес интерфейса который используется при подключении к внешним ресурсам согласно локальной таблице маршуцизации -->
   <MpRunArbiter>Запустить Arbiter</MpRunArbiter>
   <MpArbiterDesc>Копия игры, которая запускается в фоне и помогает в обнаружении/решении проблем с десинхронизацией.</MpArbiterDesc>
-  <MpAsyncTime>Асинхронное время</MpAsyncTime>
+  <MpAsyncTime>Async time</MpAsyncTime> <!-- длинна строки макс 13  -->
   <MpAsyncTimeDesc>Индивидуальное течение времени для каждой карты и планеты.</MpAsyncTimeDesc>
-  <MpHostingDevMode>Режим разработчика</MpHostingDevMode>
+  <MpHostingDevMode>Dev mode</MpHostingDevMode> <!-- длинна строки макс 13  -->
   <MpHostingDevModeDesc1>Включает доступ к инструментам режима разработчика RimWorld.</MpHostingDevModeDesc1>
   <MpHostingDevModeDesc2>Обратите внимание, что работают не все инструменты разработчика, и любая поддержка связанная с ними не оказывается.</MpHostingDevModeDesc2> <!-- Перефразировать? -->
   <MpHostingDevModeHostOnly>Только хост</MpHostingDevModeHostOnly>
   <MpHostingDevModeEveryone>Все</MpHostingDevModeEveryone>
-  <MpLogDesyncTraces>Трассировка десинхронизации</MpLogDesyncTraces>
+  <MpLogDesyncTraces>Desync traces</MpLogDesyncTraces> <!-- длинна строки макс 13  -->
   <MpLogDesyncTracesDesc1>Дополнительно логировать стеки вызов для отладки десинхронизации.</MpLogDesyncTracesDesc1>
   <MpLogDesyncTracesDesc2>Не работает на 32 битных и ARM (Apple Silicon) процессорах.</MpLogDesyncTracesDesc2>
-  <MpExperimentalFeature>Экспериментальные возможности</MpExperimentalFeature>
-  <MpSyncConfigs>Синхронизировать настройки модов</MpSyncConfigs>
+  <MpExperimentalFeature>Экспериментальная возможность</MpExperimentalFeature>
+  <MpSyncConfigs>Sync configs</MpSyncConfigs> <!-- длинна строки макс 13  -->
   <MpSyncConfigsDesc1>Дает возможность скачать настройки Ваших модов другими игроками при подключении.</MpSyncConfigsDesc1>
   <MpSyncConfigsDesc2>Включение может уменьшить количество десинхронизаций.</MpSyncConfigsDesc2>
   <MpSyncConfigsDesc3>Обратите внимание, что настройки некоторых модов могут содержать конфиденциальную информацию (Например API токены).</MpSyncConfigsDesc3>
-  <MpAutoJoinPoints>Автоматические точки подключения</MpAutoJoinPoints>
+  <MpAutoJoinPoints>Auto join-points</MpAutoJoinPoints> <!-- длинна строки макс 13  -->
   <MpAutoJoinPointsDesc1>Переключает автоматическое создание точек подключения.</MpAutoJoinPointsDesc1>
   <MpAutoJoinPointsDesc2>Создание точек подключения медленнее чем просто сохранение, но ускоряет процесс подключения игроков, так как им не требуется симулировать игру.</MpAutoJoinPointsDesc2>
   <MpAutoJoinPointsDesc3>Вы также можете самостоятельно создать точку подключения, написав /joinpoint в чат.</MpAutoJoinPointsDesc3>
@@ -195,7 +195,7 @@
   <MpSingleplayerSaves>Одиночная игра</MpSingleplayerSaves>
   <MpSaveOutdated>(Устарело)</MpSaveOutdated>
   <MpSaveOutdatedDesc>Это сохранение было сделано в RimWorld {0}, но у Вас запущенна версия {1}.</MpSaveOutdatedDesc>
-  <MpHostButton>Захостить</MpHostButton> <!-- Захостить? альтернативы? -->
+  <MpHostButton>Создать</MpHostButton> <!-- Захостить? альтернативы? -->
   <MpWatchReplay>Смотреть</MpWatchReplay> <!-- Need testing Как текст отражает суть-->
   <MpNothingSelected>Не выбрано сохранение</MpNothingSelected>
   <MpNoSaves>Мультиплеер может быть запущен только из существующих сохранений</MpNoSaves>
@@ -260,19 +260,19 @@
   <MpConfigsMatch>Настройки совпадают</MpConfigsMatch>
 
   <!-- Mod compatibility window -->
-  <MpModCompatButton>Multiplayer compatibility</MpModCompatButton>
+  <MpModCompatButton>Совместимость с Multiplayer</MpModCompatButton>
   <MpModCompatTitle>Совместимость с модом Multiplayer</MpModCompatTitle>
   <MpModCompatLoading>Загрузка</MpModCompatLoading>
   <MpModCompatLoadingFailed>Ошибка загрузки.</MpModCompatLoadingFailed>
-  <MpModCompatActiveMods>Активен</MpModCompatActiveMods>
-  <MpModCompatInstalledMods>Установлен</MpModCompatInstalledMods>
-  <MpModCompatOutdatedMods>Устарел</MpModCompatOutdatedMods>
+  <MpModCompatActiveMods>Активные</MpModCompatActiveMods>
+  <MpModCompatInstalledMods>Установленные</MpModCompatInstalledMods>
+  <MpModCompatOutdatedMods>Устаревшие</MpModCompatOutdatedMods>
   <MpModCompatHeaderModName>Имя мода</MpModCompatHeaderModName>
   <MpModCompatHeaderStatus>Статус</MpModCompatHeaderStatus>
   <MpModCompatHeaderNotes>Примечание</MpModCompatHeaderNotes>
   <MpModCompatXmlOnlyDesc>Моды состоящие только из XML файлов, без дополнительной логики, всегда совместимы. Обратите внимание, они могут использовать несовместимые моды как зависимости.</MpModCompatXmlOnlyDesc>
   <MpModCompatScore4>Все работает</MpModCompatScore4>
-  <MpModCompatScore3>В большинстве работает, некоторые незначительные функции не работают.</MpModCompatScore3>
+  <MpModCompatScore3>Почти работает, некоторые незначительные функции не работают.</MpModCompatScore3>
   <MpModCompatScore2>Частично работает, но некоторые значительные функции нет.</MpModCompatScore2>
   <MpModCompatScore1>Не работает</MpModCompatScore1>
   <MpModCompatScoreUnk>Неизвестно; пожалуйста поделитесь своими находками в канале #mod-report нашего Discord сервера</MpModCompatScoreUnk>

--- a/Russian/Keyed/Multiplayer.xml
+++ b/Russian/Keyed/Multiplayer.xml
@@ -1,132 +1,282 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <LanguageData>
 
+  <!-- Main menu -->
+  <MpMultiplayerButton>Мультиплеер</MpMultiplayerButton>
+  <MpLoadingError1>Ошибка во время загрузки мода Multiplayer.</MpLoadingError1>
+  <MpLoadingError2>Это может вызвать десинхронизацию при игре.</MpLoadingError2>
+  <MpLoadingError3>Скорее всего, это связанно с тем, что версия мода Multiplayer не совместима с Вашей версией Rimworld.</MpLoadingError3>
+  <MpLoadingError4>Вы можете попробовать обновить/откатить версию Multiplayer или Rimworld.</MpLoadingError4>
+  <MpLoadingError5>Обратите внимание, что игра могла обновится совсем недавно, и новая версия мода Multiplayer может быть ещё не доступна.</MpLoadingError5>
+
+  <!-- Ingame -->
   <MpSimulating>Симулирование</MpSimulating>
   <MpSimulatingServer>Симулирование сервера</MpSimulatingServer>
   <MpLoading>Загрузка</MpLoading>
   <MpSaving>Сохранение</MpSaving>
+  <MpCreatingJoinPoint>Создание точки подключения</MpCreatingJoinPoint> <!-- join-point = точка подключения -->
+  <MpServerCloseConfirmationNoTime>Вы уверены, что хотите закрыть сервер?</MpServerCloseConfirmationNoTime>
+  <MpServerCloseConfirmationTime>Вы уверены, что хотите закрыть сервер? Последние сохранение было {0} назад.</MpServerCloseConfirmationTime>
+  <MpTraderLeavesIn>Уходит через {0}</MpTraderLeavesIn>
+  <MpNotAvailable>Не доступно в мультиплеере.</MpNotAvailable>
+  <MpCallingFactionNotAvailable>На текущий момент вызов других фракций не доступен в мультиплеере.</MpCallingFactionNotAvailable> <!-- На момент перевода не используется -->
 
-  <MpInvalidPort>Неверный порт</MpInvalidPort>
-  <MpInvalidAddress>Неверный адрес</MpInvalidAddress>
-  <MpInvalidGameName>Неверное игровое имя</MpInvalidGameName>
+  <!-- Ticks behind indicator -->
+  <MpTicksBehind>Вы в {0} тиках позади.</MpTicksBehind>
+  <MpLowerGameSpeed>Рекомендуем снизить скорость игры.</MpLowerGameSpeed>
+  <MpForceCatchUp>Нажмите чтобы перейти в режим догоняющего.</MpForceCatchUp>
 
+  <!-- Disconnected -->
   <MpWrongProtocol>Неверная версия протокола</MpWrongProtocol>
-  <MpWrongModVersionInfo>Удостоверьтесь, что вы используете одинаковую версию мультиплеера с хостом.</MpWrongModVersionInfo>
-
-  <MpWrongDefs>Несоответствие определений в моде</MpWrongDefs>
-  <MpWrongDefsInfo>Удостоверьтесь, что ваши установленные моды, их версии и порядок совпадают с таковыми у хоста.</MpWrongDefsInfo>
-  <MpModList>Список модов</MpModList>
-  <MpSeeModList>Посмотреть список модов</MpSeeModList>
-
+  <MpWrongMultiplayerVersionInfo>Сервер использует Multiplayer {0} (протокол {1}). Ваша версия: {2}</MpWrongMultiplayerVersionInfo>
+  <MpWrongVersionUpdateInfo>Обновите мод (Переподпишитесь если используете Steam).</MpWrongVersionUpdateInfo>
+  <MpWrongVersionUpdateInfoHost>Хост должен обновить мод (Переподписаться если использует Steam).</MpWrongVersionUpdateInfoHost>
   <MpServerClosed>Сервер закрыт</MpServerClosed>
-  <MpServerFull>Сервер полон</MpServerFull>
-  <MpKicked>Вас кикнули</MpKicked>
+  <MpServerFull>Сервер полн</MpServerFull>
+  <MpDisconnectServerStarting>Сервер запускается</MpDisconnectServerStarting>
+  <MpKicked>Вы были исключены из игры</MpKicked>
+  <MpDisconnected>Отключен</MpDisconnected>
+  <MpDisconnectedWithInfo>Отключен ({0})</MpDisconnectedWithInfo>
+  <MpSteamTimedOut>Время ожидания соединения истекло</MpSteamTimedOut>
+  <MpSteamGenericError>Ошибка подключения</MpSteamGenericError>
+  <MpPacketErrorLocal>Локальная ошибка чтения пакетов. Вы можете изучить лог ошибок для дополнительной информации.</MpPacketErrorLocal>
+  <MpPacketErrorRemote>Удаленная ошибка чтения пакетов. Хост может изучить лог ошибок для дополнительной информации.</MpPacketErrorRemote>
+  <MpConnectionFailed>Подключение разорвано</MpConnectionFailed>
+  <MpConnectionFailedWithInfo>Подключение разорвано ({0})</MpConnectionFailedWithInfo>
+  <MpInvalidUsernameAlreadyPlaying>Имя пользователя уже используется</MpInvalidUsernameAlreadyPlaying>
+  <MpInvalidUsernameChars>Имя пользователя содержит недопустимые символы</MpInvalidUsernameChars>
+  <MpInvalidUsernameLength>Имя пользователя имеет недопустимую длину</MpInvalidUsernameLength>
+  <MpChangeUsernameInfo>Вы можете изменить своё имя в настройках мода.</MpChangeUsernameInfo>
+  <MpConnectAsUsername>Подключится как {0}</MpConnectAsUsername>
 
-  <MpInvalidUsernameAlreadyPlaying>Пользователь с таким именем уже есть на сервере</MpInvalidUsernameAlreadyPlaying>
-  <MpInvalidUsernameChars>В имени пользователя содержатся недопустимые символы</MpInvalidUsernameChars>
-  <MpInvalidUsernameLength>Недопустимая длина имени пользователя</MpInvalidUsernameLength>
-  <MpChangeUsernameInfo>Вы можете изменить имя пользователя .</MpChangeUsernameInfo>
-
-  <MpPlayerConnected>{0} вошел</MpPlayerConnected>
-  <MpPlayerDisconnected>{0} вышел</MpPlayerDisconnected>
-
-  <MpReplayOutdated>(Устаревшая)</MpReplayOutdated>
-  <MpReplayOutdatedDesc1>Этот реплей был сделан для версии протокола {0}, а ваша версия {1}.</MpReplayOutdatedDesc1>
-  <MpReplayOutdatedDesc2>Реплей сожет исполняться неправильно.</MpReplayOutdatedDesc2>
-  <MpReplayOutdatedDesc3>Возможное несовместимости указаны в списке релизов.</MpReplayOutdatedDesc3>
-  <MpReplayOutdatedDesc4>Данный файл содержит доп информацию и хостить с него можно.</MpReplayOutdatedDesc4>
-
-  <MpServerCloseConfirmation>Вы уверены, что хотите закрыть сервер? Несохраненный прогресс будет потерян.</MpServerCloseConfirmation>
-
-  <MpHostServer>Хостить сервер</MpHostServer>
-  <MpSaveReplay>Сохранить реплей</MpSaveReplay>
-
-  <MpConvert>Конвертировать в синглплеер</MpConvert>
-  <MpConverting>Конвертирование</MpConverting>
-
-  <MpUsername>Имя пользователя</MpUsername>
-  <MpShowPlayerCursors>Показывать курсоры пользователей</MpShowPlayerCursors>
-  <MpAutoAcceptSteam>Авто-принятие Steam</MpAutoAcceptSteam>
-  <MpAutoAcceptSteamDesc>Автоматически принимать все входящие запросы на соединения через Steam.</MpAutoAcceptSteamDesc>
-  <MpTransparentChat>Открытый чат</MpTransparentChat>
-
-  <MpAutosaveSlots>Слоты автосохранений</MpAutosaveSlots>
-  <MpAutosaveSlotsDesc>Количество файлов автосохранений.</MpAutosaveSlotsDesc>
-
-  <MpTraderLeavesIn>Покинет через {0}</MpTraderLeavesIn>
-
+  <!-- Chat -->
   <MpChatButton>Чат</MpChatButton>
-  <MpTradingButton>Торговля</MpTradingButton>
-
+  <MpChatHotkeyInfo>Горячая клавиша чата:</MpChatHotkeyInfo>
+  <MpPlayerConnected>{0} подключился</MpPlayerConnected>
+  <MpPlayerDisconnected>{0} вышел</MpPlayerDisconnected>
   <MpChatPlayers>Игроки ({0}):</MpChatPlayers>
-  <MpSend>Послать</MpSend>
-  <MpSteamAcceptTitle>Принять Steam игроков</MpSteamAcceptTitle>
+  <MpChatSend>Отправить</MpChatSend>
+    <!-- Need testing Не уверен, как выглядит это окн -->
+  <MpSteamAcceptTitle>Принять игроков из Steam</MpSteamAcceptTitle>
   <MpSteamAcceptDesc>Нажмите чтобы принять</MpSteamAcceptDesc>
   <MpSteamAccepted>Игрок был принят</MpSteamAccepted>
 
-  <MpConnectingTo>Соединение с {0}:{1}</MpConnectingTo>
-  <MpConnected>Соединен.</MpConnected>
-  <MpDownloading>Скачивание ({0}%)</MpDownloading>
+  <!-- Ingame ESC screen -->
+  <MpHostServer>Создать сервер</MpHostServer>
+  <MpConvertToSp>Конвертировать в одиночную игру</MpConvertToSp>
+  <MpConvertToSpWarnHost>Вы уверены, что хотите конвертироваться в одиночную игру? Сервер будет закрыт.</MpConvertToSpWarnHost>
+  <MpConvertToSpWarn>>Вы уверены, что хотите конвертироваться в одиночную игру? Вы покинете текущую игру.</MpConvertToSpWarn>
+  <MpConvertingToSp>Конвертирование</MpConvertingToSp>
+  <MpSaveGameAs>Сохранить игру как</MpSaveGameAs>
+  <MpWillOverwrite>Существующий файл будет перезаписан</MpWillOverwrite>
+  <MpGameSaved>Игра сохранена как {0}</MpGameSaved>
+  <MpGameSaveFailed>Ошибка сохранения игры, Вы можете изучить лог ошибок для дополнительной информации.</MpGameSaveFailed>
 
-  <MpSteamConnectingTo>Соединение с игрой, которую хостит {0}</MpSteamConnectingTo>
-  <MpSteamConnectingWaiting>Ожидание принятия хостом</MpSteamConnectingWaiting>
+  <!-- Settings -->
+  <MpUsernameSetting>Имя пользователя</MpUsernameSetting>
+  <MpShowPlayerCursors>Показывать курсоры игроков</MpShowPlayerCursors>
+  <MpAutoAcceptSteam>Авто-принятие игроков Steam</MpAutoAcceptSteam>
+  <MpAutoAcceptSteamDesc>Автоматически принимает любые входящие запросы на подключение от игроков в Steam.</MpAutoAcceptSteamDesc>
+  <MpTransparentChat>Прозрачное окно чата</MpTransparentChat>
+  <MpAutosaveSlots>Слоты автосохранения</MpAutosaveSlots>
+  <MpAutosaveSlotsDesc>Как много хранить файлов автосохранения.</MpAutosaveSlotsDesc>
+  <MpAggressiveTicking>Агрессивные тики</MpAggressiveTicking>
+  <MpAggressiveTickingDesc>Всегда пытаться автоматически догонять сервер ценой fps.</MpAggressiveTickingDesc>
+  <MpAppendNameToAutosave>Добавлять имя к автосохранению</MpAppendNameToAutosave>
+  <MpShowModCompat>Показывать совместимость модов</MpShowModCompat>
+  <MpShowModCompatDesc>Активирует загрузку и отображение рейтинга совместимости для модов на основе отзывов других игроков</MpShowModCompatDesc>
+  <MpEnablePingsSetting>Включить метки игроков</MpEnablePingsSetting> <!-- Метки = ping -->
+  <MpPingLocButtonSetting>Кнопка создания меток</MpPingLocButtonSetting>
+  <MpJumpToPingButtonSetting>Кнопка перемещения к метке</MpJumpToPingButtonSetting>
+  <MpShowMainMenuAnimation>Показывать анимацию в главном меню</MpShowMainMenuAnimation>
+  
+  <!-- Ping alert -->
+  <MpAlertPing>Многопользовательская метка</MpAlertPing>
+  <MpAlertPingDesc1>Нажмите чтобы переместится к локации отмеченной: {0}</MpAlertPingDesc1>
+  <MpAlertPingDesc2>Нажмите с зажатой клавишей shift чтобы отклонить.</MpAlertPingDesc2>
 
-  <MpTicksBehind>Вы в {0} тиках позади.</MpTicksBehind>
-  <MpLowerGameSpeed>Обдумайте уменьшение скорости игры.</MpLowerGameSpeed>
-  <MpForceCatchUp>Нажмите, чтобы насильно подобрать.</MpForceCatchUp><MpForceCatchUp>Нажмите, чтобы синхронизироваться принудительно.</MpForceCatchUp>
+  <!-- Pausing sessions -->
+  <!-- Need testing Не уверен в слове "сессия", необходимо проверить как это выглядит в игре, и скорректировать перевод -->
+  <MpDialogsButton>Диалог</MpDialogsButton>
+  <MpTradingSession>Торговая сессия</MpTradingSession>
+  <MpRitualSession>Сессия подготовки ритуала</MpRitualSession>
+  <MpTransportLoadingSession>Сессия загрузки транспортных капсул</MpTransportLoadingSession>
+  <MpCaravanFormingSession>Сессия формирования каравана</MpCaravanFormingSession>
+  <MpCaravanSplittingSession>Сессия разделения каравана</MpCaravanSplittingSession>
+  <MpAnotherRitualInProgress>Другая сессия подготовки ритуала уже запущена.</MpAnotherRitualInProgress>
 
-  <MpDesynced>Игра десинхронизирована.</MpDesynced>
-  <MpTryResync>Попробовать ресинхр.</MpTryResync>
+  <!-- Connecting -->
+  <MpConnecting>Подключение</MpConnecting>
+  <MpConnectingTo>Подключение к {0}:{1}</MpConnectingTo>
+  <MpConnected>Подключен.</MpConnected>
+  <MpJoining>Присоединение</MpJoining>
+  <MpDownloading>Загрузка ({0}%)</MpDownloading>
+  <MpSteamConnectingTo>Подключение к игре созданной {0}</MpSteamConnectingTo>
+  <MpSteamConnectingWaiting>Ожидание подтверждения хоста</MpSteamConnectingWaiting>
+  <MpWaitingForGameData>Ожидание данных игры</MpWaitingForGameData>
+  <MpInvalidAddress>Не верный адрес</MpInvalidAddress>
 
-  <MpSaveReplayAs>Сохранить реплей как</MpSaveReplayAs>
-  <MpWillOverwrite>Будет перезаписан</MpWillOverwrite>
-  <MpReplaySaved>Реплей сохранен</MpReplaySaved>
+  <!-- Desynced -->
+  <MpDesynced>Состояние игры было десинхронизированно.</MpDesynced>
+  <MpTryResync>Попробовать ресинхронизироваться</MpTryResync>
+  <MpOpenDesyncFolder>Открыть директорию с информацией</MpOpenDesyncFolder>
+  <MpDesyncedWaiting>Ожидание данных от хоста</MpDesyncedWaiting>
 
+  <!-- Hosting -->
+  <MpHostIngame>Захостить эту игру</MpHostIngame> <!-- Захостить? альтернативы? -->
+  <MpHostSavefile>Захостить игру из сохранения</MpHostSavefile>
+  <MpInvalidEndpoint>Недопустимый адрес: {0}</MpInvalidEndpoint>
+  <MpInvalidGameName>Недопустимое название игры</MpInvalidGameName>
   <MpGameName>Название игры</MpGameName>
-  <MpMaxPlayers>Макс. игроков</MpMaxPlayers>
-  <MpAutosaveEvery>Автосохранение кажд.</MpAutosaveEvery>
-  <MpAutosaveDays>дней</MpAutosaveDays>
-  <MpLanDesc1>Сделать игровую сессию доступной по локальной сети.</MpLanDesc1>
-  <MpLanDesc2>Вычисленный LAN адрес: {0}</MpLanDesc2>
-  <MpArbiterDesc>Игра, которая запускается в трее и помогает с десинхронизацией.</MpArbiterDesc>
-  <MpAsyncTime>Async time</MpAsyncTime>
-  <MpAsyncTimeDesc>Разделить контроль времени для каждой карты и планеты.</MpAsyncTimeDesc>
-  <MpExperimentalFeature>Экспериментальная фича</MpExperimentalFeature>
+  <MpMaxPlayers>Максимальное количество игроков</MpMaxPlayers>
+  <MpAutosaveIntervalMinutes>Период автосохранения (минуты)</MpAutosaveIntervalMinutes>
+  <MpAutosaveIntervalDays>Период автосохранения (дни)</MpAutosaveIntervalDays>
+  <MpAutosaveIntervalDesc1>Интервал между автосохранениями.</MpAutosaveIntervalDesc1>
+  <MpAutosaveIntervalDesc2>Нажмите чтобы переключится между игровыми днями, и реальными минутами.</MpAutosaveIntervalDesc2>
+  <MpAutosaveIntervalDesc3>Один игровой день на нормальной скорости равен примерно 16.6 минутам (быстрой: 5.5 минут, супер-быстрой: 2.7 минуты)</MpAutosaveIntervalDesc3>
+  <MpLanDesc1>Транслировать информацию об игре в локальной сети.</MpLanDesc1>
+  <MpLanDesc2>Ваш LAN адрес: {0}</MpLanDesc2> <!-- Адрес интерфейса который используется при подключении к внешним ресурсам согласно локальной таблице маршуцизации -->
+  <MpRunArbiter>Запустить Arbiter</MpRunArbiter>
+  <MpArbiterDesc>Копия игры, которая запускается в фоне и помогает в обнаружении/решении проблем с десинхронизацией.</MpArbiterDesc>
+  <MpAsyncTime>Асинхронное время</MpAsyncTime>
+  <MpAsyncTimeDesc>Индивидуальное течение времени для каждой карты и планеты.</MpAsyncTimeDesc>
+  <MpHostingDevMode>Режим разработчика</MpHostingDevMode>
+  <MpHostingDevModeDesc1>Включает доступ к инструментам режима разработчика RimWorld.</MpHostingDevModeDesc1>
+  <MpHostingDevModeDesc2>Обратите внимание, что работают не все инструменты разработчика, и любая поддержка связанная с ними не оказывается.</MpHostingDevModeDesc2> <!-- Перефразировать? -->
+  <MpHostingDevModeHostOnly>Только хост</MpHostingDevModeHostOnly>
+  <MpHostingDevModeEveryone>Все</MpHostingDevModeEveryone>
+  <MpLogDesyncTraces>Трассировка десинхронизации</MpLogDesyncTraces>
+  <MpLogDesyncTracesDesc1>Дополнительно логировать стеки вызов для отладки десинхронизации.</MpLogDesyncTracesDesc1>
+  <MpLogDesyncTracesDesc2>Не работает на 32 битных и ARM (Apple Silicon) процессорах.</MpLogDesyncTracesDesc2>
+  <MpExperimentalFeature>Экспериментальные возможности</MpExperimentalFeature>
+  <MpSyncConfigs>Синхронизировать настройки модов</MpSyncConfigs>
+  <MpSyncConfigsDesc1>Дает возможность скачать настройки Ваших модов другими игроками при подключении.</MpSyncConfigsDesc1>
+  <MpSyncConfigsDesc2>Включение может уменьшить количество десинхронизаций.</MpSyncConfigsDesc2>
+  <MpSyncConfigsDesc3>Обратите внимание, что настройки некоторых модов могут содержать конфиденциальную информацию (Например API токены).</MpSyncConfigsDesc3>
+  <MpAutoJoinPoints>Автоматические точки подключения</MpAutoJoinPoints>
+  <MpAutoJoinPointsDesc1>Переключает автоматическое создание точек подключения.</MpAutoJoinPointsDesc1>
+  <MpAutoJoinPointsDesc2>Создание точек подключения медленнее чем просто сохранение, но ускоряет процесс подключения игроков, так как им не требуется симулировать игру.</MpAutoJoinPointsDesc2>
+  <MpAutoJoinPointsDesc3>Вы также можете самостоятельно создать точку подключения, написав /joinpoint в чат.</MpAutoJoinPointsDesc3>
+  <MpAutoJoinPointsJoin>При подключении</MpAutoJoinPointsJoin>
+  <MpAutoJoinPointsDesync>При десинхронизации</MpAutoJoinPointsDesync>
+  <MpAutoJoinPointsAutosave>При автосохранении</MpAutoJoinPointsAutosave>
 
-  <MpHostButton>Хостить</MpHostButton>
-  <MpWatchReplay>Наблюдать</MpWatchReplay>
-  <MpNothingSelected>Ничего не выбрано</MpNothingSelected>
-  <MpNoSaves>Мультиплеер может быть запущен только с уже имеющихся сейвов</MpNoSaves>
+  <!-- Server browser info buttons -->
+  <MpWebsiteButton>Веб-сайт</MpWebsiteButton>
+  <MpDiscordButton>Discord</MpDiscordButton>
+  <MpLinkButtonDesc>Нажмите чтобы открыть:</MpLinkButtonDesc>
+  <MpCompatibilityButton>Совместимость</MpCompatibilityButton>
+  <MpCompatibilityButtonDesc1>Открывает окно с информацией о совместимости с модами.</MpCompatibilityButtonDesc1>
+  <MpCompatibilityButtonDesc2>Также доступна в списке модов.</MpCompatibilityButtonDesc2>
+  <!-- На момент перевода не реализовано -->
+  <MpActiveConfigsButton>Активные настройки</MpActiveConfigsButton>
+  <MpActiveConfigsButtonDesc1>Эта копия RimWorld запущенна с настройками из игры: {0}</MpActiveConfigsButtonDesc1>
+  <MpActiveConfigsButtonDesc2>Перезапустите игру, чтобы восстановить предыдущие настройки.</MpActiveConfigsButtonDesc2>
 
-  <MpHostIngame>Хостить данную игру</MpHostIngame>
-  <MpHostReplay>Хостить из реплея</MpHostReplay>
-  <MpHostSavefile>Хостить из файла сохранений</MpHostSavefile>
-
-  <MpJoinButton>Войти</MpJoinButton>
-  <MpConnectButton>Присоединиться</MpConnectButton>
-  <MpLanSearching>Поиск</MpLanSearching>
-
-  <MpNotConnectedToSteam>Нет соединения со Steam</MpNotConnectedToSteam>
-  <MpNoFriendsPlaying>Никто из друзей сейчас не играет в RimWorld</MpNoFriendsPlaying>
-  <MpPlayingRimWorld>Играет в RimWorld</MpPlayingRimWorld>
-  <MpNotInMultiplayer>Не в мультиплеере</MpNotInMultiplayer>
-
-  <MpPauseOnAutosave>Pause on Autosave</MpPauseOnAutosave>
-  <MpAppendNameToAutosave>Append Name to Autosave</MpAppendNameToAutosave>
-  <MpPauseAutosaveCounter>Pause autosave counter</MpPauseAutosaveCounter>
-  <MpPauseAutosaveCounterDesc>Pauses the counter along with the game preventing autosaving while time is paused.</MpPauseAutosaveCounterDesc>
+  <!-- Server browser tabs -->
   <MpLan>LAN</MpLan>
   <MpDirect>Прямое</MpDirect>
   <MpSteam>Steam</MpSteam>
-  <MpHostTab>Хостить</MpHostTab>
+  <MpHostTab>Создать</MpHostTab>
 
-  <MpMultiplayer>Мультиплеер</MpMultiplayer>
-  <MpSingleplayer>Одиночная</MpSingleplayer>
+  <!-- Server browser LAN and Direct tabs -->
+  <MpJoinButton>Присоединиться</MpJoinButton> <!-- Steam window -->
+  <MpConnectButton>Подключиться</MpConnectButton> <!-- Direct window -->
+  <MpLanSearching>Поиск</MpLanSearching> <!-- Lan window -->
 
-  <MpNotAvailable>Недоступно в мультиплеере.</MpNotAvailable>
-  <MpCallingFactionNotAvailable>Вызов фракций недоступен в мультиплеере.</MpCallingFactionNotAvailable>
+  <!-- Server browser Steam tab -->
+  <MpNotConnectedToSteam>Не подключен к Steam</MpNotConnectedToSteam>
+  <MpNoFriendsPlaying>Нет друзей играющих в RimWorld</MpNoFriendsPlaying>
+  <MpPlayingRimWorld>Играет RimWorld</MpPlayingRimWorld>
+  <MpNotInMultiplayer>Не в мультиплеере</MpNotInMultiplayer>
 
-  <MpAggressiveTicking>Агрессивные такты</MpAggressiveTicking>
-  <MpAggressiveTickingDesc>Всегда пытаться автоматически догонять сервер ценой частоты кадров.</MpAggressiveTickingDesc>
+  <!-- Save list -->
+  <MpMultiplayerSaves>Мультиплеер</MpMultiplayerSaves>
+  <MpSingleplayerSaves>Одиночная игра</MpSingleplayerSaves>
+  <MpSaveOutdated>(Устарело)</MpSaveOutdated>
+  <MpSaveOutdatedDesc>Это сохранение было сделано в RimWorld {0}, но у Вас запущенна версия {1}.</MpSaveOutdatedDesc>
+  <MpHostButton>Захостить</MpHostButton> <!-- Захостить? альтернативы? -->
+  <MpWatchReplay>Смотреть</MpWatchReplay> <!-- Need testing Как текст отражает суть-->
+  <MpNothingSelected>Не выбрано сохранение</MpNothingSelected>
+  <MpNoSaves>Мультиплеер может быть запущен только из существующих сохранений</MpNoSaves>
+  <MpSeeModList>Открыть список модов</MpSeeModList>
+  <MpOpenSaveFolder>Открыть директорию сохранений</MpOpenSaveFolder>
+  <MpContinueAnyway>Все равно продолжить</MpContinueAnyway>
+  <MpFileRenameButton>Переименовать</MpFileRenameButton>
+  <MpFileRename>Переименовать файл в</MpFileRename>
+  
+  <!-- Mismatch screen -->
+  <MpDataMismatch>Несовпадение данных</MpDataMismatch>
+  <MpConnectAnyway>Все равно подключится</MpConnectAnyway>
+  <MpFixAndRestart>Исправить и перезапустить</MpFixAndRestart>
+  <MpMismatchQuit>Выйти</MpMismatchQuit>
+  <MpMismatchDefsDiff>Данные определений модов отличаются. Они должны совпадать с сервером для подключения.</MpMismatchDefsDiff> <!-- Перефразировать? -->
+  <MpRestartNeeded>Для применения изменений: списка модов, файлов, и настроек, игру необходимо перезапустить.</MpRestartNeeded>
+  <MpApplyConfigs>Использовать настройки сервера</MpApplyConfigs>
+  <MpApplyConfigsTip>Использование настроек сервера временно, и Ваши настройки будут возвращены при перезапуске игры. Ваши файлы перезаписаны не будут.</MpApplyConfigsTip>
+  <MpApplyModList>Использовать список модов сервера</MpApplyModList>
+  <MpApplyModListTip>Ваш текущий список модов будет перезаписан.</MpApplyModListTip>
+  <MpMismatchGeneral>Общий</MpMismatchGeneral>
+  <MpMismatchModList>Список модов</MpMismatchModList>
+  <MpMismatchFiles>Файлы</MpMismatchFiles>
+  <MpMismatchConfigs>Настройки</MpMismatchConfigs>
+  <MpMismatchServerSide>Сервер</MpMismatchServerSide>
+  <MpMismatchClientSide>Ваш клиент</MpMismatchClientSide>
+  <MpMismatchSeeTabs>Вы можете найти дополнительную информацию в соответствующих вкладках.</MpMismatchSeeTabs>
+  <MpMismatchRwVersion>Версия RimWorld</MpMismatchRwVersion>
+  <MpMismatchMpVersion>Версия Multiplayer</MpMismatchMpVersion>
+  <MpMismatchRestart>Перезапустить</MpMismatchRestart>
+  <MpMismatchRestartDesc>Вы будете повторно подключены после перезагрузки игры.</MpMismatchRestartDesc>
+  <MpMismatchBack>Назад</MpMismatchBack>
+  <MpMismatchServerMods>Моды сервера</MpMismatchServerMods>
+  <MpMismatchLocalMods>Ваши моды</MpMismatchLocalMods>
+  <MpMismatchModListRefresh>Обновить</MpMismatchModListRefresh>
+  <MpMismatchNotInstalled>Не установлены: {0}</MpMismatchNotInstalled>
+  <MpMismatchModListsMismatch>Списки модов отличаются. Игра должна быть перезапущена.</MpMismatchModListsMismatch>
+  <MpMismatchWrongOrder>Списки модов совпадают, но их порядок отличается. Игра должна быть перезапущена.</MpMismatchWrongOrder>
+  <MpMismatchModListsMatch>Списки модов совпадают</MpMismatchModListsMatch>
+  <MpMismatchSubscribe>Подписаться на недостающие моды</MpMismatchSubscribe>
+  <MpMismatchSubscribeMsg>Подписан на {0} мод(а/ов). Загрузка в фоновом режиме...</MpMismatchSubscribeMsg>
+  <MpMismatchSubscribeNoSteam>Нет подключения к Steam. Моды должны быть установлены самостоятельно.</MpMismatchSubscribeNoSteam>
+  <MpMismatchSubscribeNoMissing>Нет недостающих модов.</MpMismatchSubscribeNoMissing>
+  <MpMismatchSubscribeDesc1>Подписаться на недостающие моды в мастерской Steam. Загрузка будет выполнена в фоне.</MpMismatchSubscribeDesc1>
+  <MpMismatchSubscribeDesc2>Не все недостающие моды доступны в мастерской Steam. Остальные должны быть установлены самостоятельно.</MpMismatchSubscribeDesc2>
+  <MpMismatchLocalFiles>Ваши файлы</MpMismatchLocalFiles>
+  <MpMismatchLocalConfigs>Ваши настройки</MpMismatchLocalConfigs>
+  <MpMismatchTreeRefresh>Обновить</MpMismatchTreeRefresh>
+  <MpMismatchTreeMissing>Отсутствует</MpMismatchTreeMissing>
+  <MpMismatchTreeAdded>Добавлен</MpMismatchTreeAdded>
+  <MpMismatchTreeModified>Изменен</MpMismatchTreeModified>
+  <MpMismatchFilesInfo>Проблема с различиями в файлах модов должна быть решена самостоятельно, или проигнорирована. Она обычно вызвана различиями в версиях модов, или файлами которые остались после обновления.</MpMismatchFilesInfo>
+  <MpMismatchFilesInfoMods>Вы можете попробовать обновить/переустановить эти моды (или переподписаться если они доступны в Steam).</MpMismatchFilesInfoMods>
+  <!-- Need testing проверить как выглядит окно, и как текст соотносится к реальности -->
+  <MpMismatchFilesInfoCore>Для решения проблем с Core и дополнениями, удалите их директории и проверьте целостность игровых файлов в Steam (Совершенно безопасно, пользовательские данные находятся в другом месте). Наведите курсор на директории выше, чтобы увидеть их нахождение.</MpMismatchFilesInfoCore>
+  <MpMismatchFilesInfoHost>Проблема также может быть на стороне хоста, и ему может быть необходимо повторить шаги выше.</MpMismatchFilesInfoHost>
+  <MpMismatchFileShowPath>Зажмите shift чтобы показать путь до файлов.</MpMismatchFileShowPath>
+  <MpMismatchFileOpenPath>Нажмите с зажатым shift чтобы перейти в директорию.</MpMismatchFileOpenPath>
+  <MpMismatchNodeExpand>Нажмите чтобы свернуть/развернуть.</MpMismatchNodeExpand>
+  <MpConfigSyncDisabled>Хост отключил синхронизацию настроек.</MpConfigSyncDisabled>
+  <MpFilesMatch>Файлы совпадают</MpFilesMatch>
+  <MpConfigsMatch>Настройки совпадают</MpConfigsMatch>
+
+  <!-- Mod compatibility window -->
+  <MpModCompatButton>Multiplayer compatibility</MpModCompatButton>
+  <MpModCompatTitle>Совместимость с модом Multiplayer</MpModCompatTitle>
+  <MpModCompatLoading>Загрузка</MpModCompatLoading>
+  <MpModCompatLoadingFailed>Ошибка загрузки.</MpModCompatLoadingFailed>
+  <MpModCompatActiveMods>Активен</MpModCompatActiveMods>
+  <MpModCompatInstalledMods>Установлен</MpModCompatInstalledMods>
+  <MpModCompatOutdatedMods>Устарел</MpModCompatOutdatedMods>
+  <MpModCompatHeaderModName>Имя мода</MpModCompatHeaderModName>
+  <MpModCompatHeaderStatus>Статус</MpModCompatHeaderStatus>
+  <MpModCompatHeaderNotes>Примечание</MpModCompatHeaderNotes>
+  <MpModCompatXmlOnlyDesc>Моды состоящие только из XML файлов, без дополнительной логики, всегда совместимы. Обратите внимание, они могут использовать несовместимые моды как зависимости.</MpModCompatXmlOnlyDesc>
+  <MpModCompatScore4>Все работает</MpModCompatScore4>
+  <MpModCompatScore3>В большинстве работает, некоторые незначительные функции не работают.</MpModCompatScore3>
+  <MpModCompatScore2>Частично работает, но некоторые значительные функции нет.</MpModCompatScore2>
+  <MpModCompatScore1>Не работает</MpModCompatScore1>
+  <MpModCompatScoreUnk>Неизвестно; пожалуйста поделитесь своими находками в канале #mod-report нашего Discord сервера</MpModCompatScoreUnk>
+  <MpHideTranslationMods>Скрыть локализационные моды</MpHideTranslationMods>
+  <MpHideTranslationModsDesc>Моды реализующие только локализацию всегда совместимы.</MpHideTranslationModsDesc>
 
 </LanguageData>


### PR DESCRIPTION
Old translation became outdated, inaccurate, misleading, and unstructured. I found easier just made translation from the ground up, then trying to fix exiting one.

I did only minimal testing for now, and leave game creation menu almost untranslated because its too narrow to put something that will be sound somewhat sentient in Russian.

Feedback and testing are welcomed.
PS. Please check ⏎ in chat menu on macos (it works on proton and linux), i used unicode return symbol as workaround of button size.