### PR TITLE
Add mod mismatch file-version and wrong-order keys (EN, RU)

### DIFF
--- a/English/Keyed/Multiplayer.xml
+++ b/English/Keyed/Multiplayer.xml
@@ -318,6 +318,7 @@
   <MpMismatchTreeMissing>Missing</MpMismatchTreeMissing>
   <MpMismatchTreeAdded>Added</MpMismatchTreeAdded>
   <MpMismatchTreeModified>Modified</MpMismatchTreeModified>
+  <MpMismatchModListWrongOrder>Wrong order</MpMismatchModListWrongOrder>
   <MpMismatchFilesInfo>Mod file differences need to be resolved manually or ignored. They are usually caused by differing versions of mods or files being left behind after an update.</MpMismatchFilesInfo>
   <MpMismatchFilesInfoMods>You should try to update/reinstall the offending mods (or resubscribe if on Steam).</MpMismatchFilesInfoMods>
   <MpMismatchFilesInfoCore>To resolve issues with Core and expansion files, remove their folders and revalidate game file integrity (safe to do so, user data is stored elsewhere). Hover over the topmost folders to see their paths.</MpMismatchFilesInfoCore>
@@ -325,6 +326,11 @@
   <MpMismatchFileShowPath>Hold shift to show the folder path.</MpMismatchFileShowPath>
   <MpMismatchFileOpenPath>Shift + click to open the folder.</MpMismatchFileOpenPath>
   <MpMismatchNodeExpand>Click to expand/collapse.</MpMismatchNodeExpand>
+  <MpMismatchFileAssemblyVersion>Assembly version</MpMismatchFileAssemblyVersion>
+  <MpMismatchFileVersion>File version</MpMismatchFileVersion>
+  <MpMismatchFileProductVersion>Product version</MpMismatchFileProductVersion>
+  <MpMismatchFileModified>Modified</MpMismatchFileModified>
+  <MpMismatchFileUnknown>unknown</MpMismatchFileUnknown>
   <MpConfigSyncDisabled>Config sync disabled by the host</MpConfigSyncDisabled>
   <MpFilesMatch>Files match</MpFilesMatch>
   <MpConfigsMatch>Configs match</MpConfigsMatch>

--- a/Russian/Keyed/Multiplayer.xml
+++ b/Russian/Keyed/Multiplayer.xml
@@ -318,6 +318,7 @@
   <MpMismatchTreeMissing>Отсутствует</MpMismatchTreeMissing>
   <MpMismatchTreeAdded>Добавлен</MpMismatchTreeAdded>
   <MpMismatchTreeModified>Изменён</MpMismatchTreeModified>
+  <MpMismatchModListWrongOrder>Неверный порядок</MpMismatchModListWrongOrder>
   <MpMismatchFilesInfo>Проблема с различиями в файлах модов должна быть решена самостоятельно или проигнорирована. Она обычно вызвана различиями в версиях модов или файлами, которые остались после обновления.</MpMismatchFilesInfo>
   <MpMismatchFilesInfoMods>Вы можете попробовать обновить/переустановить эти моды (или переподписаться, если они доступны в Steam).</MpMismatchFilesInfoMods>
   <MpMismatchFilesInfoCore>Для решения проблем с Core и дополнениями, удалите их папки и проверьте целостность игровых файлов в Steam (совершенно безопасно, пользовательские данные находятся в другом месте). Наведите курсор на папку выше, чтобы увидеть их расположение.</MpMismatchFilesInfoCore>
@@ -325,6 +326,11 @@
   <MpMismatchFileShowPath>Зажмите Shift, чтобы показать путь к файлам.</MpMismatchFileShowPath>
   <MpMismatchFileOpenPath>Нажмите с зажатым Shift, чтобы перейти в папку.</MpMismatchFileOpenPath>
   <MpMismatchNodeExpand>Нажмите, чтобы свернуть/развернуть.</MpMismatchNodeExpand>
+  <MpMismatchFileAssemblyVersion>Версия сборки</MpMismatchFileAssemblyVersion>
+  <MpMismatchFileVersion>Версия файла</MpMismatchFileVersion>
+  <MpMismatchFileProductVersion>Версия продукта</MpMismatchFileProductVersion>
+  <MpMismatchFileModified>Изменён</MpMismatchFileModified>
+  <MpMismatchFileUnknown>неизвестно</MpMismatchFileUnknown>
   <MpConfigSyncDisabled>Хост отключил синхронизацию настроек.</MpConfigSyncDisabled>
   <MpFilesMatch>Файлы совпадают</MpFilesMatch>
   <MpConfigsMatch>Настройки совпадают</MpConfigsMatch>


### PR DESCRIPTION
New keys for the join data window: MpMismatchModListWrongOrder and the per-file version tooltip labels (assembly/file/product version, modified, unknown).

Translations for https://github.com/rwmt/Multiplayer/pull/972